### PR TITLE
Optional git-repository-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ It uses the configured `git-repository-url` as the base.
 ## Requirements
 
 * The `git` command line tool.
-* A configured git repository url in your `book.toml` configuration. See [Configuration](#configuration).
 * Access to the git repository checkout while building your book.
 
 ## Installation
@@ -36,8 +35,20 @@ renderer = ["html"]
 
 ```toml
 [output.html]
-# Required: Your repository URL used in the link.
+# Optional: Your repository URL used in the link.
 git-repository-url = "https://github.com/$user/$project"
+```
+
+If `git-repository-url` is not configured the footer will not contain the commit and a link to it and instead only show the last changed date.
+
+Without `git-repository-url` configured:
+```HTML
+<footer id="last-change">Last change: 2023-07-09</footer>
+```
+
+With `git-repository-url` configured:
+```HTML
+<footer id="last-change">Last change: 2023-07-09, commit: <a href="https://github.com/$user/$project/commit/$commit">0000000</a></footer>
 ```
 
 To style the footer add a custom CSS file for your HTML output:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,26 +21,26 @@ impl Preprocessor for LastChanged {
         log::debug!("Src root: {}", src_root.display());
         log::debug!("Git root: {}", git_root.display());
 
-        let repository_url = match ctx.config.get("output.html.git-repository-url") {
-            None => {
-                log::error!("mdbook-last-changed was called, but no `output.html.git-repository-url` configured. Book is left unchanged.");
-                return Ok(book);
-            }
-            Some(url) => url,
-        };
-        let repository_url = match repository_url {
-            toml::Value::String(s) => s,
-            _ => {
-                log::trace!("git-repository-url is not a string: {repository_url:?}");
-                return Ok(book);
-            }
-        };
-        log::debug!("Repository URL: {}", repository_url);
+        let repository_string: Option<&str> = match ctx.config.get("output.html.git-repository-url") {
+            Some(val) => {
+                let url = match val {
+                    toml::Value::String(s) => s,
+                    _ => {
+                        log::trace!("git-repository-url is not a string: {val:?}");
+                        return Ok(book);
+                    }
+                };
+                log::debug!("Repository URL: {}", url);
 
-        if !repository_url.contains("github.com") {
-            log::trace!("git-repository-url is not a GitHub URL: {repository_url:?}");
-            return Ok(book);
-        }
+                if !url.contains("github.com") {
+                    log::trace!("git-repository-url is not a GitHub URL: {url:?}");
+                    return Ok(book);
+                }
+
+                Some(&url)
+            }
+            None => None,
+        };
 
         let mut res = None;
         book.for_each_mut(|item: &mut BookItem| {
@@ -51,7 +51,7 @@ impl Preprocessor for LastChanged {
 
             if let BookItem::Chapter(ref mut chapter) = *item {
                 res = Some(
-                    last_changed(&git_root, &src_root, repository_url, chapter).map(|md| {
+                    last_changed(&git_root, &src_root, repository_string, chapter).map(|md| {
                         chapter.content = md;
                     }),
                 );
@@ -65,7 +65,7 @@ impl Preprocessor for LastChanged {
 fn last_changed(
     git_root: &Path,
     src_root: &Path,
-    base_url: &str,
+    base_url: Option<&str>,
     chapter: &mut Chapter,
 ) -> Result<String> {
     let content = &chapter.content;
@@ -94,13 +94,18 @@ fn last_changed(
 
     let modification = get_last_modification(git_root, &path);
     let text = match modification {
-        Ok((date, commit)) => {
-            let url = format!("{}/commit/{}", base_url, commit);
-            format!(
-                "Last change: {}, commit: <a href=\"{}\">{}</a>",
-                date, url, commit
-            )
-        }
+        Ok((date, commit)) => match base_url {
+            Some(url) => {
+                let url = format!("{}/commit/{}", url, commit);
+                format!(
+                    "Last change: {}, commit: <a href=\"{}\">{}</a>",
+                    date, url, commit
+                )
+            }
+            None => {
+                format!("Last change: {}", date)
+            }
+        },
         Err(e) => {
             log::trace!("No modification found for {path:?}. Error: {e:?}");
             return Ok(content.into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@ impl Preprocessor for LastChanged {
         log::debug!("Src root: {}", src_root.display());
         log::debug!("Git root: {}", git_root.display());
 
-        let repository_string: Option<&str> = match ctx.config.get("output.html.git-repository-url") {
+        let repository_string: Option<&str> = match ctx.config.get("output.html.git-repository-url")
+        {
             Some(val) => {
                 let url = match val {
                     toml::Value::String(s) => s,


### PR DESCRIPTION
- Made the `git-repository-url` config optional, when its not present in the config file it'll ignore the commit part of the footer message, leaving only the last changed date visible.
- Updated the `README.md` file to take these changes into account.

The reasoning behind this change is simple, there are various circumstances such as private repos, non-github repos or simply wanting a design without the commit & its link in the footer that result in the preprocessor to become unusable due to the required `git-repository-url`. By making it optional a larger set of people are able to use it without restraints.