### PR TITLE
feat: use `<time>` tag for datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ If `git-repository-url` is not configured the footer will not contain the commit
 
 Without `git-repository-url` configured:
 ```HTML
-<footer id="last-change">Last change: 2023-07-09</footer>
+<footer id="last-change">Last change: <time datetime="2023-07-09">2023-07-09</time></footer>
 ```
 
 With `git-repository-url` configured:
 ```HTML
-<footer id="last-change">Last change: 2023-07-09, commit: <a href="https://github.com/$user/$project/commit/$commit">0000000</a></footer>
+<footer id="last-change">Last change: <time datetime="2023-07-09">2023-07-09</time>, commit: <a href="https://github.com/$user/$project/commit/$commit">0000000</a></footer>
 ```
 
 To style the footer add a custom CSS file for your HTML output:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,18 +95,16 @@ fn last_changed(
 
     let modification = get_last_modification(git_root, &path);
     let text = match modification {
-        Ok((date, commit)) => match base_url {
-            Some(url) => {
-                let url = format!("{}/commit/{}", url, commit);
-                format!(
-                    "Last change: {}, commit: <a href=\"{}\">{}</a>",
-                    date, url, commit
-                )
+        Ok((date, commit)) => {
+            let time = format!("<time datetime=\"{date}\">{date}</time>");
+            match base_url {
+                Some(url) => {
+                    let url = format!("{url}/commit/{commit}");
+                    format!("Last change: {time}, commit: <a href=\"{url}\">{commit}</a>")
+                }
+                None => format!("Last change: {time}"),
             }
-            None => {
-                format!("Last change: {}", date)
-            }
-        },
+        }
         Err(e) => {
             log::trace!("No modification found for {path:?}. Error: {e:?}");
             return Ok(content.into());


### PR DESCRIPTION
[`<time>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) can be read via computers, and may help with accessibility, such as screen readers. 